### PR TITLE
Added serialize aparameters

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -10,6 +10,9 @@ Handlebars.registerPartial('method', method)
 Handlebars.registerHelper('toLowerCase', function (word) {
   return word.toLowerCase()
 })
+Handlebars.registerHelper('json', function(context) {
+  return JSON.stringify(context);
+})
 Handlebars.registerHelper('brackets', function (word) {
   return `{${word}}`
 })

--- a/lib/template/method.hbs
+++ b/lib/template/method.hbs
@@ -55,6 +55,11 @@ if(parameters.$queryParameters) {
 
     return request('{{toLowerCase method}}', domain + path, body, queryParameters, form, config)
 }
+export const {{methodName}}_PARAMETERS = {
+    {{#parameters}}
+        {{&camelCaseName}}: {required: {{required}}, type: '{{type}}', format: '{{format}}'},
+    {{/parameters}}
+}
 
 export const {{&methodName}}_RAW_URL = function () {
   return '{{&path}}'

--- a/lib/template/method.hbs
+++ b/lib/template/method.hbs
@@ -57,10 +57,15 @@ if(parameters.$queryParameters) {
 }
 export const {{methodName}}_PARAMETERS = {
     {{#parameters}}
-        {{&camelCaseName}}: {required: {{required}}, type: '{{type}}', format: '{{format}}'},
+        {{&camelCaseName}}: {
+            {{#each this}}
+                {{#if this includeZero=false}}
+                    {{ @key }}: {{{json this}}}{{#if @last}}{{else}},{{/if}}
+                {{/if}}
+            {{/each}}
+        }{{#if @last}}{{else}},{{/if}}
     {{/parameters}}
 }
-
 export const {{&methodName}}_RAW_URL = function () {
   return '{{&path}}'
 }


### PR DESCRIPTION
Add serialize parameters to generated methods. To be able parse and know which parameters supported by api call. And to be able draw them on page, for example. 